### PR TITLE
Equal-width modifier layout calculation doesn't work as expected/described

### DIFF
--- a/lib/arrange.css
+++ b/lib/arrange.css
@@ -100,9 +100,13 @@
 /**
  * This layout algorithm will create equal-width table cells, irrespective of
  * the width of their content.
+ *
+ * 1. The layout algorithm requires a set width to correctly calculate table
+ *    cell width.
  */
 
 .Arrange--equal {
+  width: 100%; /* 1 */
   table-layout: fixed;
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -217,6 +217,29 @@
       </div>
     </div>
   </div>
+  <h3 class="Test-it">renders equal-width cells when content width varies</h3>
+  <div class="Test-run">
+    <div class="Arrange Arrange--equal">
+      <div class="Arrange-sizeFill">
+        <div class="dev-highlight">Orangutan</div>
+      </div>
+      <div class="Arrange-sizeFill">
+        <div class="dev-highlight">Gorilla</div>
+      </div>
+      <div class="Arrange-sizeFill">
+        <div class="dev-highlight">Chimpanzee</div>
+      </div>
+      <div class="Arrange-sizeFill">
+        <div class="dev-highlight">Bonobo</div>
+      </div>
+      <div class="Arrange-sizeFill">
+        <div class="dev-highlight">Gibbon</div>
+      </div>
+      <div class="Arrange-sizeFill">
+        <div class="dev-highlight">Siamang</div>
+      </div>
+    </div>
+  </div>
 
   <h2 class="Test-describe">Complex example</h2>
   <h3 class="Test-it">renders ok if you make very wide images full width in Arrange-sizeFill</h3>


### PR DESCRIPTION
As described in the docs, `.Arrange--equal` should create "equal-width cells". Through some trial and error, I've found that cells are not equal width if the width of content within them isn't uniform. It looks like what's actually happening is that the width _between cell content_ is equal, but the width of cells is not.

Applying `width: 100%` to `.Arrange--equal` makes cells actually equal width, although I don't think I understand the table layout algorithms well enough (or at all) to know why that is.

I made a couple of gifs toggling that rule for comparison.

In the test suite:

![arrange](https://cloud.githubusercontent.com/assets/808159/5079904/2a4a16a8-6e6e-11e4-90f0-1a26ea7a3a26.gif)

On Twitter:

![twitter](https://cloud.githubusercontent.com/assets/808159/5079906/2b68746c-6e6e-11e4-8afd-1f19f4e89ca7.gif)
