### PR TITLE
Standardize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,27 @@
 {
   "name": "suitcss-components-arrange",
-  "description": "SUIT CSS component for horizontal arrangement",
   "version": "1.1.1",
-  "style": "index.css",
+  "description": "SUIT CSS component for horizontal arrangement",
+  "keywords": [
+    "browser",
+    "css-components",
+    "arrange",
+    "suitcss",
+    "style"
+  ],
+  "homepage": "https://github.com/suitcss/components-arrange#readme",
+  "bugs": "https://github.com/suitcss/components-arrange/labels/bug",
+  "license": "MIT",
+  "author": "Nicolas Gallagher",
   "files": [
     "index.css",
     "index.js",
     "lib"
   ],
-  "devDependencies": {
-    "suitcss-components-test": "*",
-    "stylelint-config-suitcss": "^4.0.0",
-    "suitcss-preprocessor": "^1.0.1",
-    "suitcss-utils-display": "^1.0.2",
-    "suitcss-utils-size": "^1.0.2",
-    "suitcss-utils-text": "^1.0.0"
+  "style": "index.css",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/suitcss/components-arrange.git"
   },
   "scripts": {
     "build": "npm run setup && npm run preprocess",
@@ -26,15 +33,12 @@
     "watch": "npm run preprocess-test -- -w -v",
     "test": "npm run lint"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/suitcss/components-arrange.git"
-  },
-  "keywords": [
-    "browser",
-    "css-components",
-    "arrange",
-    "suitcss",
-    "style"
-  ]
+  "devDependencies": {
+    "suitcss-components-test": "*",
+    "stylelint-config-suitcss": "^4.0.0",
+    "suitcss-preprocessor": "^1.0.1",
+    "suitcss-utils-display": "^1.0.2",
+    "suitcss-utils-size": "^1.0.2",
+    "suitcss-utils-text": "^1.0.0"
+  }
 }


### PR DESCRIPTION
I noticed some inconsistencies and omissions in suit package info, so I tidied up:

* Arrange the package objects to match the order found in https://docs.npmjs.com/files/package.json.
* Add a `homepage` object with a link to the project’s readme on GitHub.
* Add a `bugs` object with a link to the project’s issues labeled `bug` on GitHub.
* Add an `author` object with the name of the project’s author.
* Clean up any mistakes or omissions